### PR TITLE
Add ability to specify support

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,4 +69,7 @@ app.set('reviewSlotsLimit', reviewSlotsLimit);
 var signOffSlotsLimit = process.env.REVIEW_SLOTS_LIMIT || 5;
 app.set('signOffSlotsLimit', signOffSlotsLimit);
 
+var supportStoryId = process.env.SUPPORT_STORY_ID || null;
+app.set('supportStoryId', supportStoryId);
+
 module.exports = app;

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,14 +6,20 @@ var async = require('async');
 
 function getStoryViewModel(storyDetail, membershipInfo) {
     var views = storyDetail.map(function(story) {
-        var workers = story.owner_ids.map(function(worker_id) {
-            return mapPersonFromId(worker_id, membershipInfo);
-        });
-        var signOffBy = mapPersonFromId(story.requested_by_id, membershipInfo);
-        return { id: story.id, name: story.name, signOffBy: signOffBy, workers: workers }
+        return getSingleStoryViewModel(story, membershipInfo);
     });
 
     return views;
+}
+
+function getSingleStoryViewModel(story, membershipInfo) {
+    console.log(story);
+    var workers = story.owner_ids.map(function(worker_id) {
+        return mapPersonFromId(worker_id, membershipInfo);
+    });
+    var signOffBy = mapPersonFromId(story.requested_by_id, membershipInfo);
+
+    return { id: story.id, name: story.name, signOffBy: signOffBy, workers: workers }
 }
 
 function mapPersonFromId(id, membershipInfo) {
@@ -39,11 +45,31 @@ function getStoriesByStatus(res, callback, status) {
     });
 }
 
+function getStoryById(res, callback, id) {
+    //Get the list of stories
+    var options = {
+        url: 'https://www.pivotaltracker.com/services/v5/projects/' + res.app.get('pivotalProjectId') + '/stories/' + id,
+        headers: {
+            'X-TrackerToken': res.app.get('pivotalApiKey')
+        }
+    };
+
+    request(options, function getStories(error, response, body) {
+        if (!error && response.statusCode == 200) {
+            callback(null, JSON.parse(body));
+        } else {
+            callback("Couldn't get story thanks to this crap: " + response.statusCode, null);
+        }
+    });
+}
+
 function getStorySummary(res) {
     async.parallel([
-            function(callback) {
-                getStoriesByStatus(res, callback, "started");
-            },
+            /**
+             * Get user list from Pivotal.
+             *
+             * @param callback
+             */
             function(callback) {
                 //Get the list of people
                 var options = {
@@ -61,11 +87,46 @@ function getStorySummary(res) {
                     }
                 });
             },
+            /**
+             * Get stories in play.
+             *
+             * @param callback
+             */
+            function(callback) {
+                getStoriesByStatus(res, callback, "started");
+            },
+
+            /**
+             * Get stories in review.
+             *
+             * @param callback
+             */
             function(callback) {
                 getStoriesByStatus(res, callback, "finished");
             },
-            function(callback) {
+
+            /**
+             * Get stories in approval.
+             *
+             * @param callback
+             */
+                function(callback) {
                 getStoriesByStatus(res, callback, "delivered");
+            },
+
+            /**
+             * Get support info.
+             *
+             * @param callback
+             */
+            function(callback) {
+                console.log(res.app.get('supportStoryId'));
+
+                if (res.app.get('supportStoryId')) {
+                    getStoryById(res, callback, res.app.get('supportStoryId'));
+                } else {
+                    callback(null, JSON.parse(null));
+                }
             }
         ],
         // Combine the results of the things above
@@ -73,13 +134,14 @@ function getStorySummary(res) {
             if (err) {
                 res.render('damn', { message: '┬──┬◡ﾉ(° -°ﾉ)', status: err, reason: "(╯°□°）╯︵ ┻━┻" });
             } else {
-                var startedStories = getStoryViewModel(results[0], results[1]);
-                var finishedStories = getStoryViewModel(results[2], results[1]);
-                var deliveredStories = getStoryViewModel(results[3], results[1]);
+                var startedStories = getStoryViewModel(results[1], results[0]);
+                var finishedStories = getStoryViewModel(results[2], results[0]);
+                var deliveredStories = getStoryViewModel(results[3], results[0]);
+                var support = results[4] ? getSingleStoryViewModel(results[4], results[0]) : null;
                 var reviewSlotsFull = res.app.get('reviewSlotsLimit') <= finishedStories.length;
                 var approveSlotsFull = res.app.get('signOffSlotsLimit') <= deliveredStories.length;
 
-                res.render('index', { projectId: res.app.get('pivotalProjectId'), story: startedStories, finishedStory: finishedStories, deliveredStory: deliveredStories, reviewSlotsFull: reviewSlotsFull, approveSlotsFull:approveSlotsFull });
+                res.render('index', { projectId: res.app.get('pivotalProjectId'), story: startedStories, finishedStory: finishedStories, deliveredStory: deliveredStories, reviewSlotsFull: reviewSlotsFull, approveSlotsFull:approveSlotsFull, support: support });
             }
         });
 }


### PR DESCRIPTION
## What

It is useful, to have a support name listed somewhere.

With this approach, we can create fake story, which could have a "Requester" changing every week, provide the story ID to the app, and display the name somewhere in the interface.

**WIP:** I've decided not to implement the syntax yet, just in case the other PR may be merged or rejected. Happy to implement it, after the decision has fallen.

## How to review

  - Set `SUPPORT_STORY_ID` to a random story ID from pivotal
  - Add some sample syntax (see below) for the test purpose
  - Run the application and see if the support has been displayed correctly

## Next steps

We can add similar syntax to our template:

```
<% if (support) { %>
  <p>Support: <%= support.signOffBy %></p>
<% } %>
```