### PR TITLE
Introduce optional basic auth

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at info@pengin.pro. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Feel free to contribute anything you feel suitable to this project. 
+
+* For small issues you may wish to just create a Pull Request. 
+* For larger changes it might be worth creating a Issue to discuss the change in first, then proceed onto making a Pull 
+  Request if the changes are appropriate.
+
+## Contributor Code of Conduct
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # rubbernecker
+![Rubbernecker](https://github.com/Rory80Hz/rubbernecker/blob/master/public/images/android-icon-192x192.png?raw=true)
+Pivotal is useful. But it has a weird and complex layout so it is hard to use for day to day stuff. Rubbernecker simplifies it in a Kanban-esque fashion.
 
-Pivotal is useful. But it's a weird layout so it is hard to use for day to day stuff. This is the start of a dashboard sort of thing to make something useful. For me anyway.
+It organises things by status, displays simple information about each story, who is working on it, and how long it has been in that state.
 
 ##Installation
 
@@ -8,5 +10,38 @@ Clone this repo
 
 ``` 
 npm install
+```
+
+## Running
+After completing above installation instructions, to run locally without Basic Authentication:
+
+``` 
 DEBUG=rubbernecker:* PIVOTAL_API_KEY=your-api-key PIVOTAL_PROJECT_ID=your-project-id npm start
 ```
+
+If you want to try out the stunning Basic Auth (useful for when you don't want everyone getting straight to your story overviews)
+``` 
+DEBUG=rubbernecker:* PIVOTAL_API_KEY=your-api-key PIVOTAL_PROJECT_ID=your-project-id USE_AUTH=true USERNAME=username PASSWORD=password npm start
+```
+
+### Deploying
+I've been deploying this to cloud foundry so I use the following manifest file:
+
+```
+---
+applications:
+- name: rubbernecker
+  command: npm start
+  memory: 128M
+  disk_quota: 128M
+  buildpack: nodejs_buildpack
+  env:
+    PIVOTAL_API_KEY: API KEY GOES HERE
+    PIVOTAL_PROJECT_ID: PROJECT ID GOES HERE
+    USE_AUTH: true
+    USERNAME: sensible username goes here
+    PASSWORD: sensible long password goes here
+```
+
+### Some Opinions inflicted on you
+We work in 2 week iterations so when figuring out days in a particular state we get back only the last two week of story transitions. If we don't find a thing. Feel free to raise an issue to make this configurable. It might add horrible extra work though to deal with pagination if you are working in longer iterations. If you are though; Ask yourself some questions.

--- a/app.js
+++ b/app.js
@@ -4,10 +4,17 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
-
+var utils = require('./lib/utils.js')
 var routes = require('./routes/index');
 
 var app = express();
+
+var useAuth = process.env.USE_AUTH || 'false'
+if (useAuth === 'true') {
+  var username = process.env.USERNAME
+  var password = process.env.PASSWORD
+  app.use(utils.basicAuth(username, password))
+}
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -17,7 +24,9 @@ app.set('view engine', 'ejs');
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.urlencoded({
+  extended: false
+}));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
@@ -55,8 +64,8 @@ app.use(function(err, req, res, next) {
 });
 
 /**
-* Set API Key based on Environment variable
-**/
+ * Set API Key based on Environment variable
+ **/
 var pivotalApiKey = process.env.PIVOTAL_API_KEY || 'You need to set a key';
 app.set('pivotalApiKey', pivotalApiKey);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,17 @@
+var basicAuth = require('basic-auth')
+
+exports.basicAuth = function(username, password) {
+  return function(req, res, next) {
+    if (!username || !password) {
+      return res.send('<h1>༼ つ ◕_◕ ༽つ AWWWW SNAP!</h1><p>Username or password not set. Probably go do that, given you turned on basic auth, you set it in environment variables.');
+    }
+
+    var user = basicAuth(req)
+    if (!user || user.name !== username || user.pass !== password) {
+      res.set('WWW-Authenticate', 'Basic realm=Authorization Required')
+      return res.sendStatus(401)
+    }
+
+    next()
+  }
+}


### PR DESCRIPTION
Closes #12 

In order to prevent information from being leaked putting basic auth
in place is a sensible place to start. It is optional and off by default
(open by default is a good thing to be).

Also added in code of conduct and contribution guide, and made the Readme better.